### PR TITLE
Improve testing guide and add HTTP adapter via Application config

### DIFF
--- a/lib/car_req.ex
+++ b/lib/car_req.ex
@@ -197,6 +197,7 @@ defmodule CarReq do
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
       @options CarReq.validate_options!(opts)
+      @default_adapter CarReq.Adapter.Finch
       @datadog_service_name CarReq.build_service_name(__MODULE__, opts)
       @behaviour CarReq
 
@@ -264,8 +265,16 @@ defmodule CarReq do
       def merge_options(request_options) do
         @options
         |> Keyword.merge(implementing_module: __MODULE__)
+        |> Keyword.merge(adapter: adapter())
         |> Keyword.merge(client_options())
         |> Keyword.merge(request_options)
+      end
+
+      defp adapter() do
+        config = Application.get_env(:car_req, __MODULE__, [])
+        adapter_module = config[:adapter_module] || @default_adapter
+
+        &adapter_module.run/1
       end
 
       defp telemetry_metadata(request_options) do

--- a/lib/car_req/adapter.ex
+++ b/lib/car_req/adapter.ex
@@ -1,0 +1,16 @@
+defmodule CarReq.Adapter do
+  @moduledoc """
+  Defines a behaviour for a lower-level HTTP client that will make the actual requests.
+  It has to implement `c:CarReq.Adapter.run/1`.
+  """
+
+  @doc """
+    Invoked when a request step runs.
+
+    ## Arguments
+
+    - `request` - `Req.Request` struct that stores the request data
+  """
+  @callback run(request :: Req.Request.t()) ::
+              {Req.Request.t(), Req.Response.t() | Exception.t()}
+end

--- a/lib/car_req/adapter/finch.ex
+++ b/lib/car_req/adapter/finch.ex
@@ -1,0 +1,9 @@
+defmodule CarReq.Adapter.Finch do
+  @moduledoc """
+  Default implementation of `CarReq.Adapter` that uses [finch](https://github.com/sneako/finch).
+  """
+  @behaviour CarReq.Adapter
+
+  @impl true
+  def run(%Req.Request{} = request), do: Req.Steps.run_finch(request)
+end

--- a/test/car_req/log_step_test.exs
+++ b/test/car_req/log_step_test.exs
@@ -3,7 +3,7 @@ defmodule LogStepTest do
 
   import ExUnit.CaptureLog
 
-  alias CarReq.Adapter
+  alias CarReq.Fixtures.Adapter
   alias CarReq.LogStep
 
   require Logger

--- a/test/car_req/telemetry_test.exs
+++ b/test/car_req/telemetry_test.exs
@@ -1,7 +1,7 @@
 defmodule CarReq.TelemetryTest do
   use ExUnit.Case, async: false
 
-  alias CarReq.Adapter
+  alias CarReq.Fixtures.Adapter
 
   defmodule TestTelemetryMod do
     use CarReq, compressed: true

--- a/test/fixtures/adapter.ex
+++ b/test/fixtures/adapter.ex
@@ -1,4 +1,4 @@
-defmodule CarReq.Adapter do
+defmodule CarReq.Fixtures.Adapter do
   @moduledoc "Mock adapter used for testing with `Utils.HTTPCarReq`"
 
   def success(request) do


### PR DESCRIPTION
Adds a new behavior-based adapter that makes it easier to test  HTTP clients with Mox, inspired by how Tesla does it. It also improves the testing documentation based on this new feature. 

This will allow us to stop the pattern of creating a higher-level behaviour that requires writing more code and we are mocking the actual implementation instead of the low-level HTTP/TCP calls. See the [thread](https://carscommerce.slack.com/archives/CCKSK9BJA/p1702333165685499) for more details. This will also help with reducing the amount of code we have for a single HTTP client as a side effect since DevAdapters can also be using this behaviour and return faked data by pattern matching in the URL and/or it's parameters as seen in https://github.com/codeadict/testing_carreq/blob/main/lib/colour_lovers/dev_adapter.ex#L6. 