### PR TITLE
Introduce resource_name_override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ MyResourceOverrideClient.request(
   end
 ```
 
+And finally, on a per-request basis, you can provide a hard-coded string as well rather than a 1-arity function:
+
+```elixir
+MyResourceOverrideClient.request(
+  method: :get,
+  url: url,
+  resource_name_override: "get product_details_endpoint"
+```
+
 ## Options
 
   # adapter

--- a/lib/car_req.ex
+++ b/lib/car_req.ex
@@ -186,7 +186,8 @@ defmodule CarReq do
     Req.new()
     |> Req.Request.register_options([
       :datadog_service_name,
-      :implementing_module
+      :implementing_module,
+      :resource_name_override
     ])
     |> LogStep.attach()
     |> CarReq.attach_circuit_breaker(options)
@@ -279,15 +280,10 @@ defmodule CarReq do
             Keyword.get(request_options, :datadog_service_name, @datadog_service_name),
           url: Keyword.get(request_options, :url),
           method: Keyword.get(request_options, :method),
+          resource_name_override:
+            Keyword.get(request_options, :resource_name_override, unquote(resource_name_override)),
           query_params: Keyword.get(request_options, :params)
         }
-        |> then(fn metadata ->
-          if unquote(resource_name_override) do
-            Map.put(metadata, :resource_name_override, unquote(resource_name_override))
-          else
-            metadata
-          end
-        end)
       end
 
       @doc "Set runtime options. Implement this callback for settings that will be dynamic per env."

--- a/lib/car_req.ex
+++ b/lib/car_req.ex
@@ -72,6 +72,9 @@ defmodule CarReq do
     ],
     fuse_melt_func: [
       type: {:fun, 1}
+    ],
+    resource_name_override: [
+      type: {:fun, 1}
     ]
   ]
 
@@ -268,6 +271,8 @@ defmodule CarReq do
         |> Keyword.merge(request_options)
       end
 
+      resource_name_override = Keyword.get(opts, :resource_name_override)
+
       defp telemetry_metadata(request_options) do
         %{
           datadog_service_name:
@@ -276,6 +281,13 @@ defmodule CarReq do
           method: Keyword.get(request_options, :method),
           query_params: Keyword.get(request_options, :params)
         }
+        |> then(fn metadata ->
+          if unquote(resource_name_override) do
+            Map.put(metadata, :resource_name_override, unquote(resource_name_override))
+          else
+            metadata
+          end
+        end)
       end
 
       @doc "Set runtime options. Implement this callback for settings that will be dynamic per env."

--- a/test/car_req_test.exs
+++ b/test/car_req_test.exs
@@ -780,7 +780,7 @@ defmodule CarReqTest do
           resource_name_override: &ResourceNameOverrideRuntimeClient.global_override/1
 
         def request_override(resource_name) do
-          String.replace(resource_name, "\d+", "{guid}")
+          String.replace(resource_name, ~r|\d+|, "{guid}")
         end
 
         def global_override(resource_name) do
@@ -800,7 +800,7 @@ defmodule CarReqTest do
       assert_receive {:event, [:http_car_req, :request, :start], _,
                       %{resource_name_override: override_fun}}
 
-      assert override_fun.(url) == "/employees/{guid}/details"
+      assert override_fun.(url) == ResourceNameOverrideRuntimeClient.request_override(url)
     end
 
     test "determines service name for external namespaced clients" do

--- a/test/car_req_test.exs
+++ b/test/car_req_test.exs
@@ -756,6 +756,24 @@ defmodule CarReqTest do
                       %{datadog_service_name: :guu_car_caz}}
     end
 
+    test "allows client to set a resource_name_override rule" do
+      defmodule ResourceNameOverrideClient do
+        use CarReq,
+          resource_name_override: &ResourceNameOverrideClient.resource_name_override/1
+
+        def resource_name_ovveride(resource) do
+          String.replace(resource, ~r|\d+|, "{guid}")
+        end
+      end
+
+      ResourceNameOverrideClient.request(method: :get, url: "/200", adapter: &Adapter.success/1)
+
+      assert_receive {:event, [:http_car_req, :request, :start], _,
+                      %{resource_name_override: override}}
+
+      assert is_function(override, 1)
+    end
+
     test "determines service name for external namespaced clients" do
       defmodule Test.Foo.Bar.External.Service.ServiceNameClient do
         use CarReq

--- a/test/car_req_test.exs
+++ b/test/car_req_test.exs
@@ -803,6 +803,24 @@ defmodule CarReqTest do
       assert override_fun.(url) == ResourceNameOverrideRuntimeClient.request_override(url)
     end
 
+    test "allows a hard-coded string to replace resource_name on a per-request basis rather than a function" do
+      defmodule StringResourceNameReplacementClient do
+        use CarReq
+      end
+
+      StringResourceNameReplacementClient.request(
+        method: :get,
+        url: "employees/1234/details",
+        adapter: &Adapter.success/1,
+        resource_name_override: "get employees_details_endpoint"
+      )
+
+      assert_receive {:event, [:http_car_req, :request, :start], _,
+                      %{resource_name_override: override}}
+
+      assert override == "get employees_details_endpoint"
+    end
+
     test "determines service name for external namespaced clients" do
       defmodule Test.Foo.Bar.External.Service.ServiceNameClient do
         use CarReq


### PR DESCRIPTION
This PR introduces a new option to allow for a function that can be passed to telemetry_metadata called `resource_name_override`. 

Why?

In our particular case, we generally have Datadog's default [quantization](https://docs.datadoghq.com/tracing/troubleshooting/quantization/) rules apply to external URLs with well-formed GUIDs and such; however, we have a few clients where the default quantization rules to not apply and we end up with an explosion of resources in our APM backend (Datadog). This can cause things like noisy alerts because a single failure on a single endpoint can look like a 100% error rate if there has only been one total request made. 

We can address this in one of two ways -- at our instrumentation level or by configuring our datadog agents with replacements rules. I tend to lean to wanting to do this specifically at the instrumentation level because we as developers have closer control of the rules and it does not require redeploying and configuring the Datadog agents. This PR allows us to control the resource_name replacement on a per-client and per-request basis, giving us flexibility to override resource_names at the application level when we define clients or introduce new requests.