### PR TITLE
CARS-29382: fix documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Documentation
+
+- Created CHANGELOG.md (previously referenced in mix.exs but missing)
+- Updated installation tag from `0.1.2` to `0.3.3` in README.md
+- Expanded Options section to document all `@schema` options including:
+  - `base_url`, `finch` (General)
+  - `cache`, `cache_dir`, `compressed`, `compress_body` (Response Handling)
+  - `fuse_name`, `fuse_opts`, `fuse_verbose`, `fuse_mode`, `fuse_melt_func` (Circuit Breaker)
+  - `resource_name_override` (Instrumentation)
+  - Added `:transient` as valid retry option
+- Fixed incomplete code examples (missing closing parentheses)
+- Fixed typos: "recevies" → "receives", "thorugh" → "through", "af" → "of"
+
+## [0.3.3](https://github.com/carsdotcom/car_req/compare/0.3.2...0.3.3) - 2024
+
+### Changed
+
+- Upgraded `req` from 0.5.8 to 0.5.10
+
+## [0.3.2](https://github.com/carsdotcom/car_req/compare/0.3.1...0.3.2) - 2024
+
+### Added
+
+- Support for `resource_name_override` option at client module level
+- Support for `resource_name_override` on per-request basis
+- Allow passing a hard-coded string as `resource_name_override` (not just functions)
+
+### Changed
+
+- Upgraded `req` to 0.5.8
+- Upgraded `req_fuse` to 0.3.1
+
+## [0.3.1](https://github.com/carsdotcom/car_req/compare/0.3.0...0.3.1) - 2024
+
+### Changed
+
+- Upgraded `req` and all dependencies
+- Removed unused dependencies
+
+## [0.3.0](https://github.com/carsdotcom/car_req/compare/0.2.2...0.3.0) - 2024
+
+### Added
+
+- Telemetry wrapping for request/response steps
+- Support for additional Req options (cache, cache_dir, compressed, compress_body)
+
+### Changed
+
+- Upgraded `req` to 0.4.14 (introduces improved testing mechanism)
+- Upgraded `req_fuse` to 0.3.0
+- Replaced deprecated `Req.update/2` with `Req.merge/2`
+- Updated retry config values
+- Updated GitHub Actions build versions
+
+## [0.2.2](https://github.com/carsdotcom/car_req/compare/0.2.1...0.2.2) - 2023
+
+### Changed
+
+- Updated `req` dependency
+
+## [0.2.1](https://github.com/carsdotcom/car_req/compare/0.2.0...0.2.1) - 2023
+
+### Changed
+
+- Relaxed `nimble_options` version constraint to `~> 0.4 or ~> 1.0`
+
+### Documentation
+
+- Added additional example in README
+
+## [0.2.0](https://github.com/carsdotcom/car_req/compare/0.1.1...0.2.0) - 2023
+
+### Added
+
+- `client_options/0` callback for runtime configuration
+- Support for dynamic runtime values (base_url, secrets, etc.)
+
+### Changed
+
+- Refactored implementation for cleaner code
+- Updated `req_fuse` dependency
+
+## [0.1.1](https://github.com/carsdotcom/car_req/compare/0.1.0...0.1.1) - 2023
+
+### Changed
+
+- Made `client/1` a callback
+
+## 0.1.0 - 2023
+
+### Added
+
+- Initial release
+- Opinionated wrapper for Req HTTP client
+- Circuit breaker support via `req_fuse`
+- Telemetry integration for Datadog
+- Configurable timeouts (pool_timeout, receive_timeout)
+- Retry logic with configurable strategies
+- Logging step with customizable log function
+- NimbleOptions schema validation

--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ You can also provide an override function on a per-request basis as follows:
 MyResourceOverrideClient.request(
   method: :get,
   url: url,
-  resource_name_override: fn resource_name -> 
-   String.replace(resource_name, ~r|\d+|, "{guid}")
+  resource_name_override: fn resource_name ->
+    String.replace(resource_name, ~r|\d+|, "{guid}")
   end
+)
 ```
 
 And finally, on a per-request basis, you can provide a hard-coded string as well rather than a 1-arity function:
@@ -142,28 +143,44 @@ MyResourceOverrideClient.request(
   method: :get,
   url: url,
   resource_name_override: "get product_details_endpoint"
+)
 ```
 
 ## Options
 
-  # adapter
-  - `:pool_timeout` - How long to wait to checkout a connection from the pool.
-  - `:receive_timeout` - (for Finch) The maximum time to wait for a response before returning an error.
-  - `:raw` - Bypass the decompress step on the response body step when `true`.
-  - `:decode_body` --  Bypass the decode step on the response body step when `false`.
+  ### General
+  - `:base_url` - Base URL for all requests (e.g., `"https://www.cars.com/"`).
+  - `:finch` - The Finch pool to use. Defaults to Req's default pool.
 
-  # fuse
-  - keywords for fuse configuration. See `ReqFuse`
+  ### Adapter / Timeout
+  - `:pool_timeout` - How long to wait to checkout a connection from the pool. Default: `500`.
+  - `:receive_timeout` - The maximum time to wait for a response before returning an error. Default: `1000`.
 
-  # Instrumentation (datadog)
-  - `:datadog_service_name` - An atom used to name Telemetry traces. This will be the resource name used in DataDog.
-  - `:log_function` - a 1-arity function to emit a Logger message or `:none` to skip the logging step.
+  ### Response Handling
+  - `:raw` - Bypass the decompress step on the response body when `true`. Default: `false`.
+  - `:decode_body` - Bypass the decode step on the response body when `false`. Default: `true`.
+  - `:cache` - Enable response caching when `true`.
+  - `:cache_dir` - Directory path for cached responses.
+  - `:compressed` - Request compressed response from server when `true`.
+  - `:compress_body` - Compress the request body when `true`.
 
-  # retry logic
-  - `:retry` - one of: `:safe_transient`, `false`, or a 1-arity function.
-  - `:retry_delay` - a 1-arity function to determine the delay. (Receives retry count as the argument)
-    Ex `fn count -> count * 100 end`
-  - `:max_retries` - a non-negative integer. Ignored when `retry: false`
+  ### Circuit Breaker (Fuse)
+  - `:fuse_name` - Atom name for the fuse. Defaults to the implementing module.
+  - `:fuse_opts` - Fuse trigger and reset options. Use `:disabled` to opt-out. See [ReqFuse](https://github.com/carsdotcom/req_fuse).
+  - `:fuse_verbose` - Suppress log output when `false`.
+  - `:fuse_mode` - One of `:sync` or `:async_dirty`.
+  - `:fuse_melt_func` - A 1-arity function for custom melt messages.
+
+  ### Instrumentation (Datadog)
+  - `:datadog_service_name` - An atom used to name Telemetry traces. This will be the service name used in DataDog.
+  - `:log_function` - A 1-arity function to emit a Logger message, or `:none` to skip the logging step.
+  - `:resource_name_override` - A 1-arity function to override the default resource name, or a hard-coded string.
+
+  ### Retry Logic
+  - `:retry` - One of: `:safe_transient`, `:transient`, `false`, or a 1-arity function. Default: `false`.
+  - `:retry_delay` - A 1-arity function to determine the delay (receives retry count as argument).
+    Ex: `fn count -> count * 100 end`
+  - `:max_retries` - A non-negative integer. Ignored when `retry: false`.
 
 See [Req `retry/1`](https://hexdocs.pm/req/Req.Steps.html#retry/1) for more information on
   retry options.
@@ -181,7 +198,7 @@ Override any Req option by passing the option into the underlying Req.request fu
 ### Example
 ```elixir
   defmodule ExampleImpl do
-    use CarReq
+    use CarReq,
       base_url: "https://www.cars.com/"
   end
   fake_adapter = fn request ->
@@ -207,8 +224,8 @@ See `CarReq.Adapter.success/1`.
 
 You can also pass the adapter into the request/1 function call. (See the moduledoc Example above.)
 
-When passing `:adapter` to the request function, it takes the form af a 1-arity function which
-recevies the `%Req.Request{}` struct and returns a tuple of the form `{request, %Req.Response{}}`.
+When passing `:adapter` to the request function, it takes the form of a 1-arity function which
+receives the `%Req.Request{}` struct and returns a tuple of the form `{request, %Req.Response{}}`.
 
 You may pass `Mod.fun/1` or an anonymous function as the value to the `:adapter` key.
 See the moduledoc example above for the anonymous function flavor.
@@ -216,7 +233,7 @@ See the moduledoc example above for the anonymous function flavor.
 
 ## Installation
 
-Used internally, so only available thorugh github at this time.
+Used internally, so only available through GitHub at this time.
 
 ~If [available in Hex](https://hex.pm/docs/publish),~
 The package can be installed by adding `car_req` to your list of dependencies in `mix.exs`:
@@ -224,7 +241,7 @@ The package can be installed by adding `car_req` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:car_req, git: "git@github.com:carsdotcom/car_req.git", tag: "0.1.2"}
+    {:car_req, git: "git@github.com:carsdotcom/car_req.git", tag: "0.3.3"}
   ]
 end
 ```
@@ -232,4 +249,3 @@ end
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at <https://hexdocs.pm/car_req>.
-


### PR DESCRIPTION
## What

Documentation Accuracy Audit for the `car_req` repository. This PR:
- Creates a comprehensive `CHANGELOG.md` with version history reconstructed from git tags
- Updates `README.md` with accurate version tags, complete options documentation, and fixes code examples

## Why

Part of the Marketplace Documentation & Governance initiative (CARS-29216). The goal is to ensure all documentation is accurate, current, and aligned with Marketplace standards to improve clarity for engineers and LLM tools like Cursor.

## Jira ticket

[CARS-29382](https://carscommerce.atlassian.net/browse/CARS-29362)

## Steps to Validate/Verify

Review the documentation changes:
- Verify `CHANGELOG.md` version links resolve correctly on GitHub
- Verify `README.md` code examples are syntactically correct
- Confirm all `@schema` options from `lib/car_req.ex` are documented

## Additional Notes

### Changes Summary

**CHANGELOG.md** (new file):
- Version history from 0.1.0 to 0.3.3
- Each version links to GitHub compare view
- Includes "Unreleased" section documenting this audit

**README.md**:
- Fixed installation tag: `0.1.2` → `0.3.3`
- Documented all schema options (added: `base_url`, `finch`, `cache`, `cache_dir`, `compressed`, `compress_body`, fuse options, `resource_name_override`)
- Added `:transient` as valid retry option
- Fixed incomplete code examples (missing closing parentheses)
- Fixed typos: "recevies" → "receives", "thorugh" → "through", "af" → "of"
- Added link to ReqFuse GitHub repo

## After merge checklist:

- [ ] Update version in `mix.exs` if releasing a new version
- [ ] Update `CHANGELOG.md` with changes
- [ ] Create and push a new git tag if releasing: `git tag -a X.Y.Z -m "vX.Y.Z" && git push origin X.Y.Z`
- [ ] Check [GitHub Actions](https://github.com/carsdotcom/car_req/actions) to make sure CI passes

[CARS-29382]: https://carscommerce.atlassian.net/browse/CARS-29382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ