### PR TITLE
Bump version to 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/carsdotcom/car_req/compare/0.3.3...0.3.4) - 2026-06-11
+
+### Changed
+
+- Upgraded `req` from 0.5.10 to 0.6.1
+- Upgraded `finch` from 0.19.0 to 0.22.0 (required by req 0.6.1)
+- Upgraded `mint` from 1.7.1 to 1.9.0 (required by finch 0.22)
+- Raised minimum Elixir version from `~> 1.13` to `~> 1.15` (required by finch 0.22)
+- Expanded CI matrix to cover Elixir 1.15–1.20 paired with OTP 25–29; dropped Elixir 1.14
+
 ### Documentation
 
 - Created CHANGELOG.md (previously referenced in mix.exs but missing)

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule CarReq.MixProject do
 
   @name "CarReq"
   @source_url "https://github.com/carsdotcom/car_req"
-  @version "0.3.3"
+  @version "0.3.4"
 
   def project do
     [


### PR DESCRIPTION
## What

Bumps the library version to 0.3.4 and updates CHANGELOG.md to document the changes shipping in this release.

## Why

Keeps the published version in sync with the changes landed in this release cycle — req upgrade, minimum Elixir bump, and expanded CI matrix.

## Jira ticket

N/A

## Steps to Validate/Verify

N/A — covered by automated tests and code review.

## Additional Notes

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump and changelog; no runtime or library code changes in this diff.
> 
> **Overview**
> **Release 0.3.4** — bumps `@version` in `mix.exs` from `0.3.3` to `0.3.4` so the published package matches the current release.
> 
> **CHANGELOG** — adds a `[0.3.4]` section (dated 2026-06-11) that records what ships in this release: `req`/`finch`/`mint` upgrades, minimum Elixir `~> 1.15`, CI matrix expansion, and documentation fixes previously under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e668e90769c13ff976c15b787ad53b3c2a658a67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->